### PR TITLE
The cache now gets x509ClientAuthenticationPrefixes from the director…

### DIFF
--- a/cache/advertise_test.go
+++ b/cache/advertise_test.go
@@ -110,13 +110,17 @@ func TestFilterNsAdsForCache(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		jsonbytes, err := json.Marshal(nsAds)
-		require.NoError(t, err)
+		if req.URL.String() == "/api/v2.0/director/listNamespaces" {
+			jsonbytes, err := json.Marshal(nsAds)
+			require.NoError(t, err)
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err = w.Write(jsonbytes)
-		require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(jsonbytes)
+			require.NoError(t, err)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer ts.Close()
 
@@ -141,4 +145,82 @@ func TestFilterNsAdsForCache(t *testing.T) {
 
 		})
 	}
+}
+
+func TestGetX509PrefixesFromDirector(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	nsAds := []server_structs.NamespaceAdV2{}
+	directorPrefixes := []string{"pref1", "pref2", "pref3"}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.String() == "/api/v2.0/director/listNamespaces" {
+			jsonbytes, err := json.Marshal(nsAds)
+			require.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(jsonbytes)
+			require.NoError(t, err)
+		} else {
+			jsonbytes, err := json.Marshal(directorPrefixes)
+			require.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(jsonbytes)
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	cacheServer := &CacheServer{}
+
+	err := config.InitClient()
+	require.NoError(t, err)
+	viper.Set("Federation.DirectorURL", ts.URL)
+	err = cacheServer.GetNamespaceAdsFromDirector()
+	require.NoError(t, err)
+	cachePrefixes := viper.Get("Cache.X509ClientAuthenticationPrefixes")
+	require.Equal(t, directorPrefixes, cachePrefixes)
+}
+
+func TestGetX509PrefixesFromDirectorEmpty(t *testing.T) {
+	viper.Reset()
+	defer viper.Reset()
+
+	nsAds := []server_structs.NamespaceAdV2{}
+	directorPrefixes := []string{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.String() == "/api/v2.0/director/listNamespaces" {
+			jsonbytes, err := json.Marshal(nsAds)
+			require.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(jsonbytes)
+			require.NoError(t, err)
+		} else {
+			jsonbytes, err := json.Marshal(directorPrefixes)
+			require.NoError(t, err)
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(jsonbytes)
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	cacheServer := &CacheServer{}
+
+	err := config.InitClient()
+	require.NoError(t, err)
+	viper.Set("Federation.DirectorURL", ts.URL)
+	err = cacheServer.GetNamespaceAdsFromDirector()
+	require.NoError(t, err)
+	cachePrefixes := viper.Get("Cache.X509ClientAuthenticationPrefixes")
+	require.Equal(t, directorPrefixes, cachePrefixes)
 }

--- a/director/director.go
+++ b/director/director.go
@@ -1213,6 +1213,12 @@ func listNamespacesV1(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, namespaceAdsV1)
 }
 
+func listX509ClientPrefixes(ctx *gin.Context) {
+	// Return a list of client prefixes which require x509 authenticat
+
+	ctx.JSON(http.StatusOK, param.Director_X509ClientAuthenticationPrefixes.GetStringSlice())
+}
+
 func listNamespacesV2(ctx *gin.Context) {
 	namespacesAdsV2 := listNamespacesFromOrigins()
 	namespacesAdsV2 = append(namespacesAdsV2, server_structs.NamespaceAdV2{
@@ -1336,6 +1342,7 @@ func RegisterDirectorAPI(ctx context.Context, router *gin.RouterGroup) {
 		directorAPIV1.GET("/namespaces/prefix/*path", getPrefixByPath)
 		directorAPIV1.GET("/healthTest/*path", getHealthTestFile)
 		directorAPIV1.HEAD("/healthTest/*path", getHealthTestFile)
+		directorAPIV1.GET("/listX509ClientPrefixes", listX509ClientPrefixes)
 		directorAPIV1.Any("/origin", func(gctx *gin.Context) { // Need to do this for PROPFIND since gin does not support it
 			if gctx.Request.Method == "PROPFIND" {
 				redirectToOrigin(gctx)

--- a/github_scripts/x509test.sh
+++ b/github_scripts/x509test.sh
@@ -1,0 +1,150 @@
+#!/bin/bash -xe
+#
+# Copyright (C) 2024, University of Nebraska-Lincoln
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This tests the functionality of `pelican object get` and `pelican object put` with the
+# "federation in a box"
+
+set -e
+
+mkdir -p get_put_tmp/config
+chmod 777 get_put_tmp/config
+
+mkdir -p get_put_tmp/origin
+chmod 777 get_put_tmp/origin
+
+# Setup env variables needed
+export PELICAN_FEDERATION_DIRECTORURL="https://$HOSTNAME:8444"
+export PELICAN_FEDERATION_REGISTRYURL="https://$HOSTNAME:8444"
+export PELICAN_TLSSKIPVERIFY=true
+export PELICAN_ORIGIN_ENABLEDIRECTREADS=true
+export PELICAN_SERVER_ENABLEUI=false
+export PELICAN_ORIGIN_RUNLOCATION=$PWD/xrootdRunLocation
+export PELICAN_CONFIGDIR=$PWD/get_put_tmp/config
+export PELICAN_REGISTRY_DBLOCATION=$PWD/get_put_tmp/config/test.sql
+export PELICAN_OIDC_CLIENTID="sometexthere"
+export PELICAN_ORIGIN_FEDERATIONPREFIX="/test"
+export PELICAN_ORIGIN_STORAGEPREFIX="$PWD/get_put_tmp/origin"
+export PELICAN_DIRECTOR_X509CLIENTAUTHENTICATIONPREFIXES="/test/blocked"
+
+# Function to cleanup after test ends
+cleanup() {
+    local pid=$1  # Get the PID from the function argument
+    echo "Cleaning up..."
+    if [ ! -z "$pid" ]; then
+    echo "Sending SIGINT to PID $pid"
+    kill -SIGINT "$pid"
+    else
+    echo "No PID provided for cleanup."
+    fi
+
+    # Clean up temporary files
+    rm -rf get_put_tmp
+    rm -rf xrootdRunLocation
+
+    unset PELICAN_FEDERATION_DIRECTORURL
+    unset PELICAN_FEDERATION_REGISTRYURL
+    unset PELICAN_TLSSKIPVERIFY
+    unset PELICAN_ORIGIN_FEDERATIONPREFIX
+    unset PELICAN_ORIGIN_STORAGEPREFIX
+    unset PELICAN_SERVER_ENABLEUI
+    unset PELICAN_OIDC_CLIENTID
+    unset PELICAN_ORIGIN_ENABLEDIRECTREADS
+}
+
+# Make a file to use for testing
+echo "This is some random content in the random file" > ./get_put_tmp/input.txt
+
+if [ ! -f ./pelican ]; then
+  echo "Pelican executable does not exist in PWD. Exiting.."
+  exit 1
+fi
+
+# Make a token to be used
+./pelican origin token create --audience "https://wlcg.cern.ch/jwt/v1/any" --issuer "https://`hostname`:8444" --scope "storage.read:/ storage.modify:/" --subject "origin"  --claim wlcg.ver=1.0 --lifetime 60 --private-key get_put_tmp/config/issuer.jwk > get_put_tmp/test-token.jwt
+
+echo "Token created"
+cat get_put_tmp/test-token.jwt
+
+# Run federation in the background
+federationServe="./pelican serve --module director --module registry --module origin -d"
+$federationServe &
+pid_federationServe=$!
+
+# Setup trap with the PID as an argument to the cleanup function
+trap 'cleanup $pid_federationServe' EXIT
+
+# Give the federation time to spin up:
+API_URL="https://$HOSTNAME:8444/api/v1.0/health"
+DESIRED_RESPONSE="HTTP/2 200"
+
+# Function to check if the response indicates all servers are running
+check_response() {
+    RESPONSE=$(curl -k -s -I -X GET "$API_URL" \
+                 -H "Content-Type: application/json") \
+
+    # Check if the response matches the desired output
+    if echo "$RESPONSE" | grep -q "$DESIRED_RESPONSE"; then
+        echo "Desired response received: $RESPONSE"
+        return 0
+    else
+        echo "Waiting for desired response..."
+        return 1
+    fi
+}
+
+# We don't want to do this loop for too long, indicates there is an error
+TOTAL_SLEEP_TIME=0
+
+# Loop until director, origin, and registry are running
+while check_response; [ $? -ne 0 ]
+do
+    sleep .5
+    TOTAL_SLEEP_TIME=$((TOTAL_SLEEP_TIME + 1))
+
+    # Break loop if we sleep for more than 10 seconds
+    if [ "$TOTAL_SLEEP_TIME" -gt 20 ]; then
+        echo "Total sleep time exceeded, exiting..."
+        echo "TEST FAILED"
+        exit 1
+    fi
+done
+
+# Run pelican object put
+./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/input.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/putOutput.txt
+
+# Check output of command
+if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
+    echo "Uploaded bytes successfully!"
+else
+    echo "Did not upload correctly"
+    cat get_put_tmp/putOutput.txt
+    exit 1
+fi
+
+# Run pelican object put w/ x509
+./pelican object put ./get_put_tmp/input.txt pelican://$HOSTNAME:8444/test/blocked/input.txt -d -t get_put_tmp/test-token.jwt -L get_put_tmp/putOutput.txt
+
+# Check output of command
+if grep -q "Dumping response: HTTP/1.1 200 OK" get_put_tmp/putOutput.txt; then
+    echo "Uploaded bytes successfully!"
+else
+    echo "Did not upload correctly"
+    cat get_put_tmp/putOutput.txt
+    exit 1
+fi
+
+exit 0

--- a/xrootd/resources/xrootd-cache.cfg
+++ b/xrootd/resources/xrootd-cache.cfg
@@ -58,7 +58,10 @@ pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage {{if .Cache.LowWatermark}}{{.Cache.LowWatermark}}{{else}}0.90{{end}} {{if .Cache.HighWaterMark}}{{.Cache.HighWaterMark}}{{else}}0.95{{end}} purgeinterval 300s
 xrootd.fslib ++ throttle # throttle plugin is needed to calculate server IO load
-
+http.tlsclientauth defer
+{{- range $Prefix := .Cache.X509ClientAuthenticationPrefixes}}
+http.tlsrequiredprefix {{$Prefix}}
+{{- end}}
 {{if .Cache.Concurrency}}
 throttle.throttle concurrency {{.Cache.Concurrency}}
 {{end}}

--- a/xrootd/xrootd_config.go
+++ b/xrootd/xrootd_config.go
@@ -106,18 +106,19 @@ type (
 	}
 
 	CacheConfig struct {
-		UseCmsd        bool
-		EnableVoms     bool
-		CalculatedPort string
-		HighWaterMark  string
-		LowWatermark   string
-		ExportLocation string
-		RunLocation    string
-		DataLocations  []string
-		MetaLocations  []string
-		LocalRoot      string
-		PSSOrigin      string
-		Concurrency    int
+		UseCmsd                          bool
+		EnableVoms                       bool
+		CalculatedPort                   string
+		HighWaterMark                    string
+		LowWatermark                     string
+		ExportLocation                   string
+		RunLocation                      string
+		DataLocations                    []string
+		MetaLocations                    []string
+		LocalRoot                        string
+		PSSOrigin                        string
+		Concurrency                      int
+		X509ClientAuthenticationPrefixes []string
 	}
 
 	XrootdOptions struct {

--- a/xrootd/xrootd_config_test.go
+++ b/xrootd/xrootd_config_test.go
@@ -580,6 +580,52 @@ func TestXrootDCacheConfig(t *testing.T) {
 		require.Error(t, err)
 		assert.NotNil(t, configPath)
 	})
+
+	t.Run("TestCacheHTTPTLSRequiredPrefixCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Cache.X509ClientAuthenticationPrefixes", []string{"pref1", "pref2", "pref3"})
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Contains(t, string(content), "http.tlsrequiredprefix pref1")
+		assert.Contains(t, string(content), "http.tlsrequiredprefix pref2")
+		assert.Contains(t, string(content), "http.tlsrequiredprefix pref3")
+	})
+
+	t.Run("TestCacheHTTPTLSRequiredPrefixCorrectConfig", func(t *testing.T) {
+		xrootd := xrootdTest{T: t}
+		xrootd.setup()
+
+		// Set our config
+		viper.Set("Cache.X509AuthenticationPrefixes", []string{})
+
+		// Generate the xrootd config
+		configPath, err := ConfigXrootd(ctx, false)
+		require.NoError(t, err)
+		assert.NotNil(t, configPath)
+
+		// Verify the output
+		file, err := os.Open(configPath)
+		assert.NoError(t, err)
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(content), "http.tlsrequiredprefix")
+	})
 }
 
 func TestUpdateAuth(t *testing.T) {


### PR DESCRIPTION
… and uses them in its config

	-- Creates a DirectorAPI endpoint which returns the list of x509ClientAuthenticationPrefixes
	-- The Cache retrieves this list from the director while getting NSAds from the Director
	-- The xrootd cache config now sets "http.tlsclientauth defer"
	-- for each entry in the x509ClientAuthenticationPrefixes, the xrootd cache config sets "http.tlsrequiredprefeix <prefix>"
	-- Adding tests